### PR TITLE
docs: rebranding distribution to new name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Kubernetes (please complete the following information):**
  - Kubernetes version: [e.g. 1.30.0]
- - OPA Gatekeeper version: [e.g. 3.18.0]
+ - Gatekeeper version: [e.g. 3.18.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,7 +57,7 @@ If you are opening a Draft PR, you can use the checklist to track the tests that
 have performed them.
 Example:
 
-- [ ] Tested the change with KFD version X.Y.Z
+- [ ] Tested the change with SKD version X.Y.Z
 - [ ] Tested an upgrade from the previous version X
 -->
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 <!-- markdownlint-disable MD033 -->
 <h1>
-    <img src="https://github.com/sighupio/fury-distribution/blob/main/docs/assets/fury-epta-white.png?raw=true" align="left" width="90" style="margin-right: 15px"/>
-    Kubernetes Fury OPA
+    <img src="https://github.com/sighupio/distribution/blob/main/docs/assets/fury-epta-white.png?raw=true" align="left" width="90" style="margin-right: 15px"/>
+    Policy Core Module
 </h1>
 <!-- markdownlint-enable MD033 -->
 
 ![Release](https://img.shields.io/badge/Latest%20Release-v1.14.0-blue)
-![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-opa?label=License)
+![License](https://img.shields.io/github/license/sighupio/module-policy?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
 <!-- <KFD-DOCS> -->
 
-**Kubernetes Fury OPA** provides policy enforcement at runtime for the [Kubernetes Fury Distribution (KFD)][kfd-repo].
+**Policy Core Module** provides policy enforcement at runtime for the [SIGHUP Distribution (SKD)][skd-repo].
 
-If you are new to KFD please refer to the [official documentation][kfd-docs] on how to get started with KFD.
+If you are new to SKD please refer to the [official documentation][skd-docs] on how to get started with SKD.
 
 ## Overview
 
@@ -24,13 +24,13 @@ If you are new to KFD please refer to the [official documentation][kfd-docs] on 
 
 The Kubernetes API server provides a mechanism to review every request that is made (object creation, modification, or deletion). To use this mechanism the API server allows us to create a [Validating Admission Webhook][kubernetes-vaw-docs] that, as the name says, will validate every request and let the API server know if the request is allowed or not based on some logic (policy).
 
-**Kubernetes Fury OPA** module is based on [OPA Gatekeeper][gatekeeper-page] and [Kyverno][kyverno-page], two popular open-source Kubernetes-native policy engines that runs as a Validating Admission Webhook. It allows writing custom constraints (policies) and enforcing them at runtime.
+**Policy Core Module** module is based on [Gatekeeper][gatekeeper-page] and [Kyverno][kyverno-page], two popular open-source Kubernetes-native policy engines that runs as a Validating Admission Webhook. It allows writing custom constraints (policies) and enforcing them at runtime.
 
 [SIGHUP][sighup-page] provides a set of base constraints that could be used both as a starting point to apply constraints to your current workloads and to give you an idea of how to implement new rules matching your requirements.
 
 ## Packages
 
-Fury Kubernetes OPA provides the following packages:
+Policy Core Module provides the following packages:
 
 | Package                                                | Version   | Description                                                                                                                                             |
 | ------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -58,15 +58,15 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 > [!NOTE]
 > The following instructions are for using the module with furyctl legacy, or downloading it and using it via kustomize.
 >
-> In the latest versions of the Kubernetes Fury Distribution the OPA module is natively integrated and can be used and configured by the `.spec.distribution.modules.policy` key in the configuration file.
+> In the latest versions of the SIGHUP Distribution the Policy Core Module is natively integrated and can be used and configured by the `.spec.distribution.modules.policy` key in the configuration file.
 
 ### Prerequisites
 
 | Tool                                    | Version    | Description                                                                                                                                                    |
 | --------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]                 | `>=0.27.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
+| [furyctl][furyctl-repo]                 | `>=0.27.0` | The recommended tool to download and manage SKD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
 | [kustomize][kustomize-repo]             | `>=3.10.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
-| [KFD Monitoring Module][kfd-monitoring] | `>v1.10.0` | Expose metrics to Prometheus *(optional)* and use Grafana Dashboards.                                                                                          |
+| [SKD Monitoring Module][skd-monitoring] | `>v1.10.0` | Expose metrics to Prometheus *(optional)* and use Grafana Dashboards.                                                                                          |
 
 > You can comment out the service monitor in the [kustomization.yaml][core-kustomization] file if you don't want to install the monitoring module.
 
@@ -146,7 +146,7 @@ add this to the `patches/allow.yml` file:
 
 #### Emergency brake
 
-If for some reason OPA Gatekeeper is giving you issues and blocking normal operations in your cluster, you can disable it by removing the Validating Admission Webhook definition from your cluster:
+If for some reason Gatekeeper is giving you issues and blocking normal operations in your cluster, you can disable it by removing the Validating Admission Webhook definition from your cluster:
 
 ```bash
 kubectl delete ValidatingWebhookConfiguration gatekeeper-validating-webhook-configuration
@@ -156,7 +156,7 @@ kubectl delete ValidatingWebhookConfiguration gatekeeper-validating-webhook-conf
 
 Gatekeeper is configured by default in this module to expose some Prometheus metrics about its health, performance, and operative information.
 
-You can monitor and review these metrics by checking out the provided Grafana dashboard. (This requires the KFD Monitoring Module to be installed).
+You can monitor and review these metrics by checking out the provided Grafana dashboard. (This requires the SKD Monitoring Module to be installed).
 
 Go to your cluster's Grafana and search for the "Gatekeeper" dashboard:
 
@@ -226,12 +226,12 @@ kustomize build . | kubectl apply --server-side -f -
 [kubernetes-vaw-docs]: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 
 [core-kustomization]: ./katalog/gatekeeper/core/kustomization.yaml
-[compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-opa/blob/main/docs/COMPATIBILITY_MATRIX.md
+[compatibility-matrix]: https://github.com/sighupio/module-policy/blob/main/docs/COMPATIBILITY_MATRIX.md
 
 [sighup-page]: https://sighup.io
-[kfd-repo]: https://github.com/sighupio/fury-distribution
-[kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[kfd-monitoring]: https://github.com/sighupio/fury-kubernetes-monitoring
+[skd-repo]: https://github.com/sighupio/distribution
+[skd-docs]: https://docs.kubernetesfury.com/docs/distribution/
+[skd-monitoring]: https://github.com/sighupio/module-monitoring
 [furyctl-repo]: https://github.com/sighupio/furyctl
 [kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
 
@@ -245,7 +245,7 @@ Before contributing, please read the [Contributing Guidelines](docs/CONTRIBUTING
 
 ### Reporting Issues
 
-In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/fury-kubernetes-opa/issues/new/choose).
+In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/module-policy/issues/new/choose).
 
 ## License
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
-Please refer to the contributing section in [KFD's official documentation][kfd-contributing] to learn how to contribute.
+Please refer to the contributing section in [SKD's official documentation][skd-contributing] to learn how to contribute.
 
-[kfd-contributing]: https://docs.kubernetesfury.com/docs/contribute
+[skd-contributing]: https://docs.kubernetesfury.com/docs/contribute

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -5,4 +5,4 @@
 Changes between `1.0.0` and this release: `1.0.1`
 
 - FIX: constraint `enforcementaction` typo: `enforcementAction`. This didn't get caught before because deny is the
-  default enforcement action for constraints: <https://github.com/sighupio/fury-kubernetes-opa/pull/3>
+  default enforcement action for constraints: <https://github.com/sighupio/module-policy/pull/3>

--- a/docs/releases/v1.10.0.md
+++ b/docs/releases/v1.10.0.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.10.0
+# Policy Core Module Release 1.10.0
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release including the following changes:
 

--- a/docs/releases/v1.11.0.md
+++ b/docs/releases/v1.11.0.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.11.0
+# Policy Core Module Release 1.11.0
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release including the following changes:
 

--- a/docs/releases/v1.11.1.md
+++ b/docs/releases/v1.11.1.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.11.1
+# Policy Core Module Release 1.11.1
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a patch release including the following changes:
 

--- a/docs/releases/v1.12.0.md
+++ b/docs/releases/v1.12.0.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.12.0
+# Policy Core Module Release 1.12.0
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release including the following changes:
 

--- a/docs/releases/v1.13.0.md
+++ b/docs/releases/v1.13.0.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.13.0
+# Policy Core Module Release 1.13.0
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release including the following changes:
 

--- a/docs/releases/v1.14.0.md
+++ b/docs/releases/v1.14.0.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release v1.14.0
+# Policy Core Module Release v1.14.0
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release including the following changes:
 
@@ -8,7 +8,7 @@ This is a minor release including the following changes:
 - Drop support for Kubernetes 1.28
 - Update Gatekeeper to version 3.18.2
 - Update Kyverno to version 1.13.4
-- [[#114]](https://github.com/sighupio/fury-kubernetes-opa/pull/114) Add kapp `rebaseRule` configuration to avoid replacing Gatekeeper's webhook TLS secret content. Notice that this change applies only when using the module trough `furyctl apply`.
+- [[#114]](https://github.com/sighupio/module-policy/pull/114) Add kapp `rebaseRule` configuration to avoid replacing Gatekeeper's webhook TLS secret content. Notice that this change applies only when using the module trough `furyctl apply`.
 
 
 ## Component Images 🚢
@@ -48,4 +48,4 @@ Removal of wildcard permissions:
 Default exception settings:
 - In Kyverno v1.12 and previous versions, policy exceptions were enabled by default for all namespaces. The new default in Kyverno v1.13 no longer automatically enables exceptions for all namespaces, instead requires explicit configuration of the namespaces to which exceptions apply, which may need to be added.
 
-For more details check the [PR](https://github.com/sighupio/fury-kubernetes-opa/pull/117).
+For more details check the [PR](https://github.com/sighupio/module-policy/pull/117).

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,4 +1,4 @@
-# OPA Core Module version 1.2.0
+# Policy Core Module version 1.2.0
 
 SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
 With the Kubernetes 1.19 release, it became the perfect time to start testing this module against this Kubernetes

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -1,6 +1,6 @@
-# OPA Core Module version 1.2.1
+# Policy Core Module version 1.2.1
 
-This release removes the cert-manager dependency created in [1.2.0](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.2.0)
+This release removes the cert-manager dependency created in [1.2.0](https://github.com/sighupio/module-policy/releases/tag/v1.2.0)
 due to a [fix applied to the gatekeeper upstream project](https://github.com/open-policy-agent/gatekeeper/pull/811)
 
 ## Changelog

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,4 +1,4 @@
-# OPA Core Module version v1.3.0
+# Policy Core Module version v1.3.0
 
 SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
 With the Kubernetes 1.20 release, it became the perfect time to start testing this module against this Kubernetes
@@ -8,7 +8,7 @@ Continue reading the [Changelog](#changelog) to discover them:
 
 ## Changelog
 
-- Update OPA Gatekeeper version from: 3.1.1 to [3.2.2](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.2.2)
+- Update Gatekeeper version from: 3.1.1 to [3.2.2](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.2.2)
 - Include Gatekeeper Policy Manager, GPM, from our amazing @ralgozino. [0.4.1](https://github.com/sighupio/gatekeeper-policy-manager/releases/tag/v0.4.1).
 - Adds `excludeIstio` flag to:
   - `K8sLivenessProbe`

--- a/docs/releases/v1.3.1.md
+++ b/docs/releases/v1.3.1.md
@@ -1,4 +1,4 @@
-# OPA Core Module version v1.3.1
+# Policy Core Module version v1.3.1
 
 This patch contains only the change (and few examples) to move the container image from the `reg.sighup.io` registry
 to `registry.sighup.io`.

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,4 +1,4 @@
-# OPA Core Module version v1.4.0
+# Policy Core Module version v1.4.0
 
 SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
 With the Kubernetes 1.21 release, it became the perfect time to start testing this module against this Kubernetes
@@ -8,7 +8,7 @@ Continue reading the [Changelog](#changelog) to discover them:
 
 ## Changelog
 
-- Update OPA Gatekeeper version from: 3.2.2 to [3.4.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.4.0)
+- Update Gatekeeper version from: 3.2.2 to [3.4.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.4.0)
   - Add Pod Disruption Budget
 - Kubernetes support:
   - Deprecate Kubernetes 1.17 support.

--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -1,25 +1,25 @@
-# Opa Core Module version 1.5.0
+# Policy Core Module version 1.5.0
 
-`fury-kubernetes-opa` is part of the SIGHUP maintained [Kubernetes Fury
-Distribution](https://github.com/sighupio/fury-distribution). The module
-provides a policy engine based on OPA Gatekeeper to enable custom policy
+`module-policy` is part of the SIGHUP maintained [SIGHUP
+Distribution](https://github.com/sighupio/distribution). The module
+provides a policy engine based on Gatekeeper to enable custom policy
 enforcement to be deployed on the Kubernetes cluster based on Velero.
 Team SIGHUP makes it a priority to maintain these modules in compliance
 with CNCF and with all the latest features from upstream.
 
 This release introduces the support for Kubernetes runtime `1.22` and
 drops support for `1.18`. Refer the [Compatibility
-Matrix](https://github.com/sighupio/fury-kubernetes-opa#compatibility) for more.
+Matrix](https://github.com/sighupio/module-policy#compatibility) for more.
 
 ## Changelog
 
 ### Breaking Changes
 > None
 ### Features
-- [#30](https://github.com/sighupio/fury-kubernetes-opa/pull/30) Supporting e2e test for 1.22.0 kubernetes
-- [#32](https://github.com/sighupio/fury-kubernetes-opa/pull/32) Updating GPM to 0.5.0
-- [#33](https://github.com/sighupio/fury-kubernetes-opa/pull/33) Upgrading gatekeeper from v3.4.0 to [v3.6.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.6.0)
-- [#31](https://github.com/sighupio/fury-kubernetes-opa/pull/31) Fixing OPA CRDs to support Kubernetes 1.22
+- [#30](https://github.com/sighupio/module-policy/pull/30) Supporting e2e test for 1.22.0 kubernetes
+- [#32](https://github.com/sighupio/module-policy/pull/32) Updating GPM to 0.5.0
+- [#33](https://github.com/sighupio/module-policy/pull/33) Upgrading gatekeeper from v3.4.0 to [v3.6.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.6.0)
+- [#31](https://github.com/sighupio/module-policy/pull/31) Fixing OPA CRDs to support Kubernetes 1.22
 ### Bug Fixes
 > None
 ### Security Fixes

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -1,8 +1,8 @@
 <h1>:x: This release contains issues, please use the version v1.6.2 instead :x:</h1>
 
-# OPA Core Module Release 1.6.0
+# Policy Core Module Release 1.6.0
 
-Welcome to the latest release of `OPA` module of (`Kubernetes Fury
+Welcome to the latest release of `Policy` module of (`SIGHUP
 Distribution`)[https://github.com/sighupio/fury-distribution] maintained by team
 SIGHUP.
 
@@ -27,11 +27,11 @@ kubernetes release `v1.23.0`.
 
 ## Breaking Changes 💔
 
-- [#40](https://github.com/sighupio/fury-kubernetes-opa/pull/40) Added Kubernetes labels to all the components of the module: Since `labels` are immutable fields in deployments, daemonsets, etc., this change requires a recreation of those resources.
+- [#40](https://github.com/sighupio/module-policy/pull/40) Added Kubernetes labels to all the components of the module: Since `labels` are immutable fields in deployments, daemonsets, etc., this change requires a recreation of those resources.
 
 ## Features 💥
 
-- [#35](https://github.com/sighupio/fury-kubernetes-opa/pull/35) Protecting namespaces from accidental deletion (optional)
+- [#35](https://github.com/sighupio/module-policy/pull/35) Protecting namespaces from accidental deletion (optional)
   - We added a Constraint Template and a Constraint to protect namespaces for being deleted. If you want to avoid accidental deletion of a namespace, you shuold add the following annotation to your namespace
     ```yaml
     annotations:
@@ -57,11 +57,11 @@ kubernetes release `v1.23.0`.
     operation != "DELETE"
     ```
     To enable the watching of `DELETE` events (needed by the namespace protection rule) you have to remove the comment in the lines `37` and `62` in file [vwh.yml]((../../katalog/gatekeeper/core/vwh.yaml))
-- [#40](https://github.com/sighupio/fury-kubernetes-opa/pull/40) Added e2e-test support for k8s runtime `1.23`
-- [#40](https://github.com/sighupio/fury-kubernetes-opa/pull/40) Added Makefile, JSON builder and .bumpversion config to the module
-- [#41](https://github.com/sighupio/fury-kubernetes-opa/pull/41) Upgrade `gatekeeper` image to `v3.7.0`
-- [#42](https://github.com/sighupio/fury-kubernetes-opa/pull/42) Add k8s 1.23 e2e-testing support for OPA module
-- [#43](https://github.com/sighupio/fury-kubernetes-opa/pull/43) update Gatekeeper Policy Manager to v0.5.1
+- [#40](https://github.com/sighupio/module-policy/pull/40) Added e2e-test support for k8s runtime `1.23`
+- [#40](https://github.com/sighupio/module-policy/pull/40) Added Makefile, JSON builder and .bumpversion config to the module
+- [#41](https://github.com/sighupio/module-policy/pull/41) Upgrade `gatekeeper` image to `v3.7.0`
+- [#42](https://github.com/sighupio/module-policy/pull/42) Add k8s 1.23 e2e-testing support for Policy module
+- [#43](https://github.com/sighupio/module-policy/pull/43) update Gatekeeper Policy Manager to v0.5.1
 
 ## Update Guide 🦮
 

--- a/docs/releases/v1.6.1.md
+++ b/docs/releases/v1.6.1.md
@@ -1,15 +1,15 @@
 <h1>:x: This release contains issues, please use the version v1.6.2 instead :x:</h1>
 
-# OPA Core Module Release 1.6.1
+# Policy Core Module Release 1.6.1
 
-Welcome to the latest release of `OPA` module of (`Kubernetes Fury
+Welcome to the latest release of `Policy` module of (`SIGHUP
 Distribution`)[https://github.com/sighupio/fury-distribution] maintained by team
 SIGHUP.
 
 This is a patch release fixing a bug and improving some documentation for the module.
 
 > 💡 Please refer the release notes of the minor version
-> [`v1.6.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.6.0)
+> [`v1.6.0`](https://github.com/sighupio/module-policy/releases/tag/v1.6.0)
 > if you are upgrading from a version `< v1.6.0`
 
 ## Component Images 🚢
@@ -24,8 +24,8 @@ This is a patch release fixing a bug and improving some documentation for the mo
 
 ## Documentation 📕
 
-- [#45](https://github.com/sighupio/fury-kubernetes-opa/pulls/45) Improve
-  and restructure the documentation of the opa module
+- [#45](https://github.com/sighupio/module-policy/pulls/45) Improve
+  and restructure the documentation of the Policy module
 
 ## Update Guide 🦮
 

--- a/docs/releases/v1.6.2.md
+++ b/docs/releases/v1.6.2.md
@@ -1,13 +1,13 @@
-# OPA Core Module Release 1.6.2
+# Policy Core Module Release 1.6.2
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury
-Distribution](https://github.com/sighupio/fury-distribution) maintained by team
+Welcome to the latest release of `Policy` module of [SIGHUP
+Distribution](https://github.com/sighupio/distribution) maintained by team
 SIGHUP.
 
 This is a patch release fixing a bug with a missing mount for `gatekeeper-audit` and reverts the `commonLabels` applied in `v1.6.0` because they break updating the module in the future.
 
 > 💡 Please refer the release notes of the minor version
-> [`v1.6.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.6.0)
+> [`v1.6.0`](https://github.com/sighupio/module-policy/releases/tag/v1.6.0)
 > if you are upgrading from a version `< v1.6.0`
 
 ## Component Images 🚢

--- a/docs/releases/v1.7.0.md
+++ b/docs/releases/v1.7.0.md
@@ -1,7 +1,7 @@
 
-# OPA Core Module Release v1.7.0
+# Policy Core Module Release v1.7.0
 
-Welcome to the latest release of the `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This release includes the following changes:
 

--- a/docs/releases/v1.7.1.md
+++ b/docs/releases/v1.7.1.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.7.1
+# Policy Core Module Release 1.7.1
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a patch release including the following changes:
 
@@ -9,7 +9,7 @@ This is a patch release including the following changes:
 - Updated Gatekeeper Policy Manager to v1.0.2.
 - Add official support for Kubernetes v1.24.x
 
-> 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
+> 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/module-policy/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
 
 ## Component Images 🚢
 

--- a/docs/releases/v1.7.2.md
+++ b/docs/releases/v1.7.2.md
@@ -1,13 +1,13 @@
-# OPA Core Module Release 1.7.2
+# Policy Core Module Release 1.7.2
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a patch release including the following changes:
 
 - Added `pomerium`, `calico-apiserver` and `vmware-system-csi` namespaces to the default rules exclusions.
 - Updated Gatekeeper to v3.9.2 from v3.9.0, fixing a CVE and improving performance.
 
-> 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
+> 💡 Please refer the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/module-policy/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
 
 ## Component Images 🚢
 

--- a/docs/releases/v1.7.3.md
+++ b/docs/releases/v1.7.3.md
@@ -1,13 +1,13 @@
-# OPA Core Module Release 1.7.3
+# Policy Core Module Release 1.7.3
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a patch release including the following changes:
 
-- Removed references to deprecated Ingress API in Gatekeeper's config and custom rules ([#88](https://github.com/sighupio/fury-kubernetes-opa/pull/88))
+- Removed references to deprecated Ingress API in Gatekeeper's config and custom rules ([#88](https://github.com/sighupio/module-policy/pull/88))
 - Updated documentation
 
-> 💡 Please refer to the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/fury-kubernetes-opa/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
+> 💡 Please refer to the release notes of the minor version [`v1.7.0`](https://github.com/sighupio/module-policy/releases/tag/v1.7.0) if you are upgrading from a version `< v1.7.0`
 
 ## Component Images 🚢
 

--- a/docs/releases/v1.8.0.md
+++ b/docs/releases/v1.8.0.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.8.0
+# Policy Core Module Release 1.8.0
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release including the following changes:
 

--- a/docs/releases/v1.9.0.md
+++ b/docs/releases/v1.9.0.md
@@ -1,6 +1,6 @@
-# OPA Core Module Release 1.9.0
+# Policy Core Module Release 1.9.0
 
-Welcome to the latest release of `OPA` module of [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `Policy` module of [SIGHUP Distribution](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release including the following changes:
 

--- a/katalog/gatekeeper/README.md
+++ b/katalog/gatekeeper/README.md
@@ -1,4 +1,4 @@
-# OPA Gatekeeper
+# Gatekeeper
 
 <!-- <KFD-DOCS> -->
 

--- a/katalog/gatekeeper/core/MAINTENANCE.md
+++ b/katalog/gatekeeper/core/MAINTENANCE.md
@@ -30,7 +30,7 @@ diff the generated `local.yaml` with the `upstream.yaml` file and port the neede
 
 Please notice that it is expected that some objects don't have the namespace set as in upstream, this is because the namespace is set with Kustomize.
 
-1. Sync the new image to our registry by updating the [OPA images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/opa/images.yml).
+1. Sync the new image to our registry by updating the [OPA images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/opa/images.yml).
 
 2. Update the `kustomization.yaml` file with the new version in the image tag.
 

--- a/katalog/gatekeeper/gpm/README.md
+++ b/katalog/gatekeeper/gpm/README.md
@@ -2,7 +2,7 @@
 
 <!-- KFD-DOCS -->
 
-**Gatekeeper Policy Manager** is a simple *read-only* web UI for viewing OPA Gatekeeper policies' status in a Kubernetes Cluster.
+**Gatekeeper Policy Manager** is a simple *read-only* web UI for viewing Gatekeeper policies' status in a Kubernetes Cluster.
 
 The target Kubernetes Cluster can be the same where GPM is running or some other [remote cluster(s) using a `kubeconfig` file][gpm-multicluster-readme].
 
@@ -10,7 +10,7 @@ GPM can display all the defined **Constraint Templates** with their rego code, a
 
 ## Requirements
 
-You'll need [OPA Gatekeeper][gatekeeper-pkg] running in your cluster and at least some constraint templates and constraints defined to take advantage of this tool.
+You'll need [Gatekeeper][gatekeeper-pkg] running in your cluster and at least some constraint templates and constraints defined to take advantage of this tool.
 
 ### Resources
 

--- a/katalog/gatekeeper/monitoring/README.md
+++ b/katalog/gatekeeper/monitoring/README.md
@@ -4,7 +4,7 @@
 
 This package includes:
 
-- a Prometheus `ServiceMonitor` definition to instruct the KFD Monitoring module to gather the metrics from OPA Gatekeeper
+- a Prometheus `ServiceMonitor` definition to instruct the SKD Monitoring module to gather the metrics from Gatekeeper
 - a custom set of Prometheus rules to alert when Gatekeeper's webhooks are misbehaving
 - a custom Grafana Dashboard that shows the mentioned metrics in a nice visual way.
 

--- a/katalog/gatekeeper/rules/README.md
+++ b/katalog/gatekeeper/rules/README.md
@@ -4,7 +4,7 @@
 
 A Policy is a group of rules that enforce desired behavior. The module provides a set of common policies out of the box to get started in securing your cluster.
 
-A policy in OPA Gatekeeper is defined by two objects: a `ConstraintTemplate` and a `Constraint`.
+A policy in Gatekeeper is defined by two objects: a `ConstraintTemplate` and a `Constraint`.
 
 As the name suggests, the `ConstraintTemplate` defines the common logic of the policy and the `Constraint` takes that logic and creates the actual policy by creating an instance of the template with the right values for the required parameters.
 
@@ -14,7 +14,7 @@ For example, one could have a `ConstraintTemplate` to check that a set of labels
 
 ## SIGHUP base rules
 
-Below, you can find a list of constraint templates shipped with Kubernetes Fury Distribution:
+Below, you can find a list of constraint templates shipped with SIGHUP Distribution:
 
 | Rule Name                  | Description                                                                                                                                           |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -27,9 +27,9 @@ Below, you can find a list of constraint templates shipped with Kubernetes Fury 
 > [security_controls_template.yml][security-controls-template]: it's an all-in-one pod security policy measure composed of several rules. Most of the rules are commented out and provided as examples and to be used as starting point for your own rules.
 > This file can be split into several `ConstraintTemplates` with the counterpart of having to manage an additional `constraint`/`constraintTemplate` resource for each one.
 <!-- space left blank on purpose to separate both quotes -->
-> The KFD OPA package provides both `ConstraintTemplates` and `Constraints` for each rule out of the box.
+> The SKD Gatekeeper package provides both `ConstraintTemplates` and `Constraints` for each rule out of the box.
 <!-- space left blank on purpose to separate both quotes -->
-> All the `Constraints` exclude by default KFD "infra" namespaces (`kube-system`, `logging`, `monitoring`, `ingress-nginx`, `cert-manager`) to avoid service disruption.
+> All the `Constraints` exclude by default SKD "infra" namespaces (`kube-system`, `logging`, `monitoring`, `ingress-nginx`, `cert-manager`) to avoid service disruption.
 
 ### Usage
 

--- a/katalog/kyverno/MAINTENANCE.md
+++ b/katalog/kyverno/MAINTENANCE.md
@@ -22,7 +22,7 @@ helm template kyverno /tmp/kyverno --values MAINTENANCE.values.yaml --set crds.i
 
 2. Overwrite the content of the generated from chart crds.yaml with the content of the katalog/kyverno/core/crds.yaml file.
 
-3. Sync the new image to our registry by updating the [OPA images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/opa/images.yml).
+3. Sync the new image to our registry by updating the [OPA images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/opa/images.yml).
 
 4. Update the `kustomization.yaml` file with the new version in the image tag.
 

--- a/katalog/kyverno/README.md
+++ b/katalog/kyverno/README.md
@@ -20,11 +20,11 @@ Kyverno is a policy engine designed for Kubernetes. It can validate, mutate, and
 
 ## Configuration
 
-Kyverno is deployed in HA mode, and whitelists the KFD `infra` namespaces by default on the webhooks.
+Kyverno is deployed in HA mode, and whitelists the SKD `infra` namespaces by default on the webhooks.
 
 ## Pre-configured policies
 
-This package comes with a set of predefined policies from the main kyverno repository. These policies are our own KFD baseline, and are similar to what is provided with the Gatekeeper package.
+This package comes with a set of predefined policies from the main kyverno repository. These policies are our own SKD baseline, and are similar to what is provided with the Gatekeeper package.
 
 | Policy                         | Description                                                                                                                                                                                                                                                                                                                          |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
### Summary 💡

The goal of this PR is to rebrand Kubernetes Fury Distribution (KFD) to SIGHUP Distribution (SKD).

### Tests performed 🧪

No tests are needed.