### PR TITLE
fix(ci): add dependencies between pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -210,6 +210,7 @@ type: docker
 
 depends_on:
   - Linting
+  - E2E Tests Kubernetes v1.29.8
 
 clone:
   depth: 1
@@ -336,6 +337,7 @@ type: docker
 
 depends_on:
   - Linting
+  - E2E Tests Kubernetes v1.30.4
 
 clone:
   depth: 1
@@ -462,6 +464,7 @@ type: docker
 
 depends_on:
   - Linting
+  - E2E Tests Kubernetes v1.31.0
 
 clone:
   depth: 1


### PR DESCRIPTION
### Summary 💡

Added dependencies between pipelines to avoid creating 8 Kind clusters simultaneously.

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [ ] Run e2e [e2e-20250402-1](https://ci.sighup.io/sighupio/module-policy/825)

### Future work 🔧

None.
